### PR TITLE
Move @wdio/types to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,10 +14,10 @@
   },
   "devDependencies": {
     "@types/node": "^14.0.5",
-    "@types/which": "^1.3.2",
     "typescript": "^3.9.3"
   },
   "dependencies": {
+    "@types/which": "^1.3.2",
     "which": "^2.0.2"
   }
 }


### PR DESCRIPTION
The way you are exposing type definitions for this module requires to move `@types/which` into the dependency section otherwise users of this module like the [webdriverio project](https://github.com/webdriverio/webdriverio) see an error when trying to compile:

> packages/devtools/node_modules/edge-paths/src/main.ts(3,19): error TS7016: Could not find a declaration file for module 'which'. '/Users/christianbromann/Sites/WebdriverIO/webdriverio/packages/devtools/node_modules/which/which.js' implicitly has an 'any' type.                                                                                                   Try `npm install @types/which` if it exists or add a new declaration (.d.ts) file containing `declare module 'which';